### PR TITLE
Handle missing device-data directory

### DIFF
--- a/rime/filesystem.py
+++ b/rime/filesystem.py
@@ -343,12 +343,19 @@ class FilesystemRegistry:
         Return a mapping of key -> filesystem type for each valid filesystem under base_path.
         """
         filesystems = {}
-        for filename in os.listdir(self.base_path):
-            path = os.path.join(self.base_path, filename)
 
-            for fs_cls in FILESYSTEM_TYPE_TO_OBJ.values():
-                if fs_cls.is_device_filesystem(path):
-                    filesystems[filename] = fs_cls(filename, path)
+        try:
+            for filename in os.listdir(self.base_path):
+                path = os.path.join(self.base_path, filename)
+
+                for fs_cls in FILESYSTEM_TYPE_TO_OBJ.values():
+                    if fs_cls.is_device_filesystem(path):
+                        filesystems[filename] = fs_cls(filename, path)
+        except FileNotFoundError:
+            # display red-colored warning on terminal
+            red = "\x1b[31;20m"
+            reset = "\x1b[0m"
+            log.warning(red + f"Could not find filesystem directory: {self.base_path}" + reset)
 
         return filesystems
 

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# trap signals to exit processes started by the script and
+# terminate them when the script exits or fails
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+
 set -e
 
 PYTHON=${PYTHON:-python3.10}


### PR DESCRIPTION
Without having the device-data files the server was throwing a `FileNotFoundError`. The script was exiting and the frontend was still running.

This PR:
- Updates the `run_dev.sh` script so that all processes terminate when the script exits.
- Updates the **rime server** so it can work even when no device-data is loaded.

I encountered these issues while trying to run without having device-data present.