### PR TITLE
Add usage info messages on UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Rime is configured through its YAML configuration file. If you're using `run_dev
 `frontend/rime_settings.yaml`. However, RIME will open and use `frontend/rime_settings.local.yaml` if it exists, so you
 may prefer to copy existing configuration to the `local` version if you wish to make changes.
 
+The `filesystem.base_path` setting specifies the path where the device data
+should be for the rime server to access them and serve them to the frontend.
+If there are no device data under the `base_path` then the UI will
+not show any available devices.
+
 #### Plugins
 
 RIME supports a plugin architecture, currently in development. The only plugin you can use at the moment is `ml_names`,

--- a/frontend/src/components/DeviceChooser.vue
+++ b/frontend/src/components/DeviceChooser.vue
@@ -41,6 +41,16 @@ async function toggleDeviceActive(id) {
 			<span class="country_code">{{ device.country_code }}</span>
 			<div class="delete" v-if="device.is_subset && !device.is_locked" @click="deleteDevice(device.id)">&#10060;</div>
 		</div>
+		<div v-if="devices.length === 0">
+			<p>No data detected.</p>
+			<p class="text-box">
+				You can configure the location of the device data in the
+				<code>rime_settings.yaml</code> or
+				<code>rime_settings.local.yaml</code>
+				file and restart the server. Each device in the directory
+				will appear in a list here.
+			</p>
+		</div>
 	</div>
 </template>
 
@@ -67,4 +77,31 @@ label.locked {
 	cursor: default;
 }
 
+/* Github-style inline code formatting: https://stackoverflow.com/a/22997770 */
+pre {
+    border-radius: 5px;
+    -moz-border-radius: 5px;
+    -webkit-border-radius: 5px;
+    border: 1px solid #BCBEC0;
+    background: #F1F3F5;
+    font:12px Monaco,Consolas,"Andale  Mono","DejaVu Sans Mono",monospace
+}
+
+code {
+    border-radius: 5px;
+    -moz-border-radius: 5px;
+    -webkit-border-radius: 5px;
+    border: 1px solid #BCBEC0;
+    padding: 2px;
+    font:12px Monaco,Consolas,"Andale  Mono","DejaVu Sans Mono",monospace
+}
+
+pre code {
+    border-radius: 0px;
+    -moz-border-radius: 0px;
+    -webkit-border-radius: 0px;
+    border: 0px;
+    padding: 2px;
+    font:12px Monaco,Consolas,"Andale  Mono","DejaVu Sans Mono",monospace
+}
 </style>

--- a/frontend/src/components/SearchResults.vue
+++ b/frontend/src/components/SearchResults.vue
@@ -303,10 +303,23 @@ function * eventsRowGenerator() {
 				<div v-else class="event"></div>
 			</template>
 		</div>
+		<div v-if="searchResult.events.length === 0" class="center text-box">
+			Select one or more devices to view the messages.
+			When more than one device is selected the messages will be
+			date- and time-aligned across the selected devices. Messages
+			on one device may appear later than messages on anonther
+			device.
+		</div>
 	</div>
 </template>
 
 <style scoped>
+
+.center {
+	margin: auto;
+	margin-top: 15%;
+	width: 20%;
+}
 
 .rowContainer {
 	display: flex;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -38,6 +38,14 @@ body {
     margin: 0.2em 1em -1em 1em;
 }
 
+.text-box {
+	border-color: #eee;
+	border-style: solid;
+	padding: 4px 8px;
+	border-radius: 4px;
+	margin-left: -8px;
+}
+
 h1 {
 	font-size: 18px;
 	font-weight: normal;


### PR DESCRIPTION
This PR:
- Adds minor explanation on README on how to specify where the data is located.
- Adds UI messages. See following image on how it looks.

---

![rime-pr-ui-usage-messages](https://github.com/horizon-institute/rime/assets/3640109/e4d8bb55-554c-4822-a927-b1eca6cd73d5)
