### PR TITLE
Format files with flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,17 @@
+# configuration for flake8 linter
+[flake8]
+ignore=
+    # continuation line over-indented for hanging indent
+    E126,
+    # continuation line under-indented for visual indent
+    E128,
+    # line break before binary operator: this is conflicting with W504
+    W503
+
+max-line-length=120
+
+per-file-ignores=
+    frontend/rimeserver.py:E402
+    rime/__init__.py:F401
+    rime/providers/__init__.py:F401
+    rime/graphql.py:F841

--- a/frontend/rimeserver.py
+++ b/frontend/rimeserver.py
@@ -29,6 +29,7 @@ else:
     print("Configuration file not found. Create rime_settings.yaml or set RIME_CONFIG.")
     sys.exit(1)
 
+
 class RimeScheduler(Scheduler):
     def __init__(self, my_thread_executor, bg_thread_executor):
         super().__init__()
@@ -46,6 +47,7 @@ class RimeScheduler(Scheduler):
         Schedule a function to run on the background thread. Returns a future.
         """
         return self._bg_thread_executor.submit(fn, *args, **kwargs)
+
 
 class RimeSingleton:
     """
@@ -75,7 +77,9 @@ class RimeSingleton:
     def get_media(self, media_id):
         return self._run(self._rime.get_media, media_id)
 
+
 rime = RimeSingleton(rime_config)
+
 
 @app.after_request
 def add_cors_headers(response):
@@ -84,14 +88,17 @@ def add_cors_headers(response):
     response.headers['Access-Control-Allow-Methods'] = 'GET, POST, OPTIONS'
     return response
 
+
 @app.route('/media/<path:media_id>', methods=['GET'])
 def handle_media(media_id):
     media_id = urllib.parse.unquote(media_id)
     return handle_get_media(media_id)
 
+
 @app.route('/graphql', methods=['POST'])
 def handle_graphql():
     return handle_post_graphql(request)
+
 
 def handle_get_media(media_id):
     media_data = rime.get_media(media_id)
@@ -99,6 +106,7 @@ def handle_get_media(media_id):
     response = make_response(send_file(media_data.handle, mimetype=media_data.mime_type))
     response.headers['Content-Length'] = str(media_data.length)
     return response
+
 
 def handle_post_graphql(request):
     query_json = request.get_json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ charset-normalizer==3.1.0
 click==8.1.3
 Django==4.1.3
 exceptiongroup==1.1.1
+flake8==6.0.0
 Flask==2.3.2
 frozenlist==1.3.3
 fs==2.4.16
@@ -22,10 +23,13 @@ iniconfig==2.0.0
 itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.2
+mccabe==0.7.0
 multidict==6.0.4
 packaging==23.0
 phonenumbers==8.13.6
 pluggy==1.0.0
+pycodestyle==2.10.0
+pyflakes==3.0.1
 PyPika==0.48.9
 pytest==7.2.2
 PyYAML==6.0

--- a/rime/__init__.py
+++ b/rime/__init__.py
@@ -1,6 +1,6 @@
 # This software is released under the terms of the GNU GENERAL PUBLIC LICENSE.
 # See LICENSE.txt for full details.
 # Copyright 2023 Telemarq Ltd
- 
+
 from .rime import Rime
 import graphql

--- a/rime/config.py
+++ b/rime/config.py
@@ -2,6 +2,7 @@ import os.path
 
 from ruamel.yaml import YAML
 
+
 class Config:
     """
     Global configuration for RIME using a YAML file.

--- a/rime/contact.py
+++ b/rime/contact.py
@@ -5,11 +5,12 @@
 from dataclasses import dataclass
 from typing import Any
 
+
 @dataclass
 class Name:
-    first: str|None = None
-    last: str|None = None
-    display: str|None = None
+    first: str | None = None
+    last: str | None = None
+    display: str | None = None
 
     def full_name(self):
         if self.display:
@@ -23,16 +24,17 @@ class Name:
 
         return ''
 
+
 # TODO: a Contact may have more than one phone or email
 @dataclass
 class Contact:
     local_id: str  # Unique to the provider only. The GraphQL layer combines this with providerName for the UI.
     device_id: str
-    name: Name|None = None
-    providerName: str|None = None
-    providerFriendlyName: str|None = None
-    phone: str|None = None
-    email: str|None = None
+    name: Name | None = None
+    providerName: str | None = None
+    providerFriendlyName: str | None = None
+    phone: str | None = None
+    email: str | None = None
     # Provider-specific data to allow the contact to be recreated during subsetting:
     provider_data: Any = None
 
@@ -49,6 +51,7 @@ class Contact:
 
     def __hash__(self):
         return hash((self.device_id, self.local_id))
+
 
 @dataclass(frozen=True)
 class GlobalContactId:

--- a/rime/event.py
+++ b/rime/event.py
@@ -14,13 +14,15 @@ from typing import Any
 from .contact import Contact
 from .providers.provider import Provider
 
+
 @dataclass
 class Event:
     id_: str
     timestamp: datetime
     provider: Provider
-    device_id: str|None = None  # Added by graphql layer, no need to set in Provider
+    device_id: str | None = None  # Added by graphql layer, no need to set in Provider
     provider_data: Any = None
+
 
 @dataclass(kw_only=True)
 class MessageSession:
@@ -34,6 +36,7 @@ class MessageSession:
         key = f'{self.session_id}:{self.provider.NAME}'
         return hash(key)
 
+
 @dataclass(kw_only=True)
 class Media:
     """
@@ -42,14 +45,16 @@ class Media:
     mime_type: str
     local_id: str  # A provider-specific reference to the media.
 
+
 @dataclass(kw_only=True)
 class MessageEvent(Event):
     session_id: str
     text: str
-    sender: Contact|None = None
+    sender: Contact | None = None
     from_me: bool = False
-    session: MessageSession|None = None
-    media: Media|None = None
+    session: MessageSession | None = None
+    media: Media | None = None
+
 
 @dataclass(kw_only=True)
 class MediaEvent(Media, Event):

--- a/rime/filter.py
+++ b/rime/filter.py
@@ -6,9 +6,9 @@ from re import Pattern
 from datetime import datetime
 from dataclasses import dataclass
 
-from .providers import Provider
 from .event import MessageEvent
 from .contact import GlobalContactId
+
 
 class _AlwaysMatchesPattern:
     def search(self, input):
@@ -17,22 +17,25 @@ class _AlwaysMatchesPattern:
     def match(self, input):
         return True
 
+
 TheAlwaysMatchesPattern = _AlwaysMatchesPattern()
+
 
 @dataclass
 class ProvidersFilter:
-    name_regex: Pattern|_AlwaysMatchesPattern
+    name_regex: Pattern | _AlwaysMatchesPattern
 
     @classmethod
     def empty(cls):
         return cls(name_regex=TheAlwaysMatchesPattern)
 
+
 @dataclass
 class EventsFilter:
-    participant_ids: list[GlobalContactId]|None = None
-    timestamp_start: datetime|None = None
-    timestamp_end: datetime|None = None
-    type_names: set[str]|None = None
+    participant_ids: list[GlobalContactId] | None = None
+    timestamp_start: datetime | None = None
+    timestamp_end: datetime | None = None
+    type_names: set[str] | None = None
 
     def accepts_type(self, type_name):
         return self.type_names is None or type_name in self.type_names
@@ -69,9 +72,10 @@ class EventsFilter:
 
         return True
 
+
 @dataclass
 class ContactsFilter:
-    name_regex: Pattern|_AlwaysMatchesPattern
+    name_regex: Pattern | _AlwaysMatchesPattern
 
     @classmethod
     def empty(cls):

--- a/rime/media.py
+++ b/rime/media.py
@@ -1,6 +1,7 @@
 import typing
 from dataclasses import dataclass
 
+
 @dataclass
 class MediaData:
     mime_type: str

--- a/rime/mergedcontact.py
+++ b/rime/mergedcontact.py
@@ -8,13 +8,16 @@ import phonenumbers
 
 from .contact import Contact, Name
 
+
 @dataclass
 class MergedContact:
-    local_id: str  # Unique to the provider only. The GraphQL layer combines this with device ID and providerName for the UI.
+    # local_id: Unique to the provider only. The GraphQL layer combines this with device ID and providerName for the UI.
+    local_id: str
     contacts: list[Contact]
-    name: Name|None = None
-    phone: str|None = None
-    email: str|None = None
+    name: Name | None = None
+    phone: str | None = None
+    email: str | None = None
+
 
 def _hash_contact_ids(contacts) -> str:
     hasher = hashlib.sha256()
@@ -24,6 +27,7 @@ def _hash_contact_ids(contacts) -> str:
         hasher.update(contact.providerName.encode('utf-8'))
 
     return hasher.hexdigest()
+
 
 def merge_contacts(rime, contacts: list[Contact]) -> list[MergedContact]:
     """

--- a/rime/plugins/__init__.py
+++ b/rime/plugins/__init__.py
@@ -7,6 +7,7 @@ from ruamel.yaml import YAML
 
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 
+
 @dataclass
 class Plugin:
     name: str
@@ -14,7 +15,7 @@ class Plugin:
     config: dict
     module_name: str
     func_name: str
-    _fn: Callable|None
+    _fn: Callable | None
 
     @property
     def fn(self):
@@ -26,6 +27,7 @@ class Plugin:
             self._fn = getattr(module, self.func_name)
 
         return self._fn
+
 
 def load_plugin(category, name):
     plugin_dir = os.path.join(BASE_PATH, category)

--- a/rime/plugins/anonymise/ml_names/anonymise_name.py
+++ b/rime/plugins/anonymise/ml_names/anonymise_name.py
@@ -1,13 +1,12 @@
-import os
-
 from transformers import pipeline
 
 # There's nothing special about this particular model or revision. They are just what pipeline('ner') gave me by
-# default. 
+# default.
 AI_NER_MODEL = 'dbmdz/bert-large-cased-finetuned-conll03-english'
-AI_NER_REVISION ='f2482bf'
+AI_NER_REVISION = 'f2482bf'
 
 _tokeniser = pipeline('ner', model=AI_NER_MODEL, revision=AI_NER_REVISION, aggregation_strategy='first')
+
 
 def do_name_anonymisation(value):
     """

--- a/rime/providers/androidcontacts.py
+++ b/rime/providers/androidcontacts.py
@@ -26,10 +26,12 @@ from ..sql import Table, Query, get_field_indices
 from ..contact import Contact, Name
 from ..anonymise import anonymise_phone, anonymise_email, anonymise_name
 
+
 @dataclass
 class AndroidContact:
     contact_row_id: str
     raw_contact_row_ids: set[str]
+
 
 # Maps filesystem identifier to {id: mime type}
 MIMETYPE_TO_ID = {}
@@ -41,12 +43,14 @@ MIMETYPES = {
     'vnd.android.cursor.item/email_v2': 'email',
 }
 
+
 def filter_contacts(filter, contacts_iterable):
     if not filter:
         return contacts_iterable
 
     return [contact for contact in contacts_iterable
             if filter.name_regex.match(contact.name.display)]
+
 
 class AndroidContacts(Provider):
     NAME = 'android-com.android.providers.contacts'
@@ -97,8 +101,8 @@ class AndroidContacts(Provider):
             if contact_id not in contacts:
                 provider_data = AndroidContact(contact_row_id=contact_id, raw_contact_row_ids=set())
                 contacts[contact_id] = Contact(
-                    local_id=contact_id, 
-                    device_id=self.fs.id_, 
+                    local_id=contact_id,
+                    device_id=self.fs.id_,
                     name=Name(),
                     providerName=self.NAME,
                     providerFriendlyName=self.FRIENDLY_NAME,
@@ -180,7 +184,7 @@ class AndroidContacts(Provider):
             obj = cls(fs)
             if obj.is_version_compatible():
                 return obj
-        
+
         return None
 
     def get_media(self, local_id):

--- a/rime/providers/androidtelephony.py
+++ b/rime/providers/androidtelephony.py
@@ -19,10 +19,12 @@ from ..anonymise import anonymise_phone, anonymise_name
 TYPE_TO_ME = 1
 TYPE_FROM_ME = 2
 
+
 @dataclass
 class AtMessage:
     threads_table_id: str
     address_table_id: str
+
 
 class AndroidTelephony(Provider, LazyContactProvider):
     NAME = "android-com.android.providers.telephony"
@@ -117,8 +119,12 @@ class AndroidTelephony(Provider, LazyContactProvider):
         rows_threads = subsetter.row_subset('threads', '_id')
         rows_address = subsetter.row_subset('canonical_addresses', '_id')
 
-        rows_address.update(contact.local_id for contact in contacts if contact.providerName == self.NAME)
-        rows_threads.update(event.provider_data.threads_table_id for event in events if event.provider.NAME == self.NAME)
+        rows_address.update(
+            contact.local_id for contact in contacts if contact.providerName == self.NAME
+        )
+        rows_threads.update(
+            event.provider_data.threads_table_id for event in events if event.provider.NAME == self.NAME
+        )
         rows_sms.update(event.id_ for event in events if event.provider.NAME == self.NAME)
 
         subsetter.create_db_and_copy_rows(self.db, self.MMSSMS_DB, [

--- a/rime/providers/androidwhatsapp.py
+++ b/rime/providers/androidwhatsapp.py
@@ -31,12 +31,15 @@ JID_TYPE_BROADCAST = 5
 JID_TYPE_ME = 11
 JID_TYPE_USER = 17
 
+
 def _timestamp_to_datetime(timestamp):
     # Timestamps in whatsapp are stored as milliseconds since the epoch
     return datetime.datetime.fromtimestamp(timestamp / 1000)
 
+
 def _datetime_to_timestamp(dt):
     return int(dt.timestamp() * 1000)
+
 
 @dataclass
 class WhatsappJid:
@@ -51,6 +54,7 @@ class WhatsappJid:
     name: str  # jid.display_name, a phone number or group ID
     typ: int  # JID_TYPE_*
 
+
 @dataclass
 class WhatsappContact:
     """
@@ -63,8 +67,10 @@ class WhatsappContact:
     number: str
     display_name: str
     jid_contacts: list[WhatsappJid]
+
     def typ_contains(self, typ):
         return any(wa_contact.typ == typ for wa_contact in self.jid_contacts)
+
 
 @dataclass
 class WhatsappMessageSession:
@@ -74,8 +80,8 @@ class WhatsappMessageSession:
     This goes into MessageSession.provider_data.
     """
     group_participant_user_ids: set[str]
-    group_user_id: str|None
-    group_jid_row_id: str|None
+    group_user_id: str | None
+    group_jid_row_id: str | None
 
 
 CONTACTS_BY_JID_ROW_ID = {}  # Maps FS ID to {jid_row_id: Contact}
@@ -87,12 +93,14 @@ GROUP_USERS = {}  # Maps FS ID to {group jid: list of user jids}
 # group_participant_user table indices, by filesystem ID
 GROUP_PARTICIPANT_USER_IDS = {}  # Maps FS ID to {group jid: list of group participant user _id fields}
 
+
 # Extra information for message events, for recreation during subsetting.
 @dataclass
 class WhatsappMessageEvent:
     # Row IDs in various tables:
     message_row_id: str
     chat_row_id: str
+
 
 class AndroidWhatsApp(Provider):
     NAME = 'android-com.whatsapp.android'
@@ -132,10 +140,10 @@ class AndroidWhatsApp(Provider):
         for row in self.wadb.execute(str(query)):
             jid = row[fields['jid']]
             wa_contact = WhatsappContact(
-                id_ = row[fields['_id']],
-                jid = jid,
-                number = row[fields['number']],
-                display_name = row[fields['display_name']],
+                id_=row[fields['_id']],
+                jid=jid,
+                number=row[fields['number']],
+                display_name=row[fields['display_name']],
                 jid_contacts=[]
             )
             new_contact = Contact(

--- a/rime/providers/imessage.py
+++ b/rime/providers/imessage.py
@@ -7,7 +7,6 @@ Provides Apple 'Messages'
 import datetime
 from dataclasses import dataclass
 from typing import Iterable
-from typing_extensions import dataclass_transform
 
 from .provider import Provider
 from .providerutils import LazyContactProvider, LazyContactProviderContacts
@@ -16,14 +15,17 @@ from ..contact import Contact, Name
 from ..sql import Table, Query, get_field_indices
 from ..anonymise import anonymise_phone, anonymise_name
 
+
 @dataclass
 class ImessageContact:
     row_id: str
+
 
 @dataclass
 class ImessageMessage:
     message_row_id: str
     chat_row_id: str
+
 
 class IMessage(Provider, LazyContactProvider):
     NAME = 'ios-com.apple.messages'
@@ -34,7 +36,7 @@ class IMessage(Provider, LazyContactProvider):
 
     # Timestamps in imessage are (I think) stored as nanoseconds since 1/1/2001.
     # I'm guessing UTC?
-    EPOCH = datetime.datetime(2001,1,1,0,0)
+    EPOCH = datetime.datetime(2001, 1, 1, 0, 0)
     EPOCH_TS = int(EPOCH.timestamp())
 
     def __init__(self, fs):
@@ -51,7 +53,7 @@ class IMessage(Provider, LazyContactProvider):
 
     @classmethod
     def _datetime_to_timestamp(cls, dt):
-        return int((dt.timestamp()-cls.EPOCH_TS) * 1_000_000_000)
+        return int((dt.timestamp() - cls.EPOCH_TS) * 1_000_000_000)
 
     def _create_session(self, chat_id):
         # Retrieve contacts

--- a/rime/providers/ioscontacts.py
+++ b/rime/providers/ioscontacts.py
@@ -5,7 +5,6 @@
 """
 Provides ios contacts
 """
-from dataclasses import dataclass
 from typing import Iterable
 
 from .provider import Provider
@@ -13,6 +12,7 @@ from ..contact import Contact, Name
 from ..sql import Table, Query, get_field_indices
 from ..event import Event
 from ..anonymise import anonymise_phone, anonymise_email, anonymise_name
+
 
 class IOSContacts(Provider):
     NAME = 'ios-AddressBook'
@@ -27,7 +27,6 @@ class IOSContacts(Provider):
 
     def __del__(self):
         self.conn.close()
-
 
     def is_version_compatible(self):
         return True
@@ -44,7 +43,7 @@ class IOSContacts(Provider):
         # Phone numbers will have property=3, emails will have property=4
         # Some may have neither.
         query = Query.from_(person_table).left_join(mvtable).on(person_table.ROWID == mvtable.record_id).select(
-            person_table.ROWID, person_table.First, person_table.Last, 
+            person_table.ROWID, person_table.First, person_table.Last,
             mvtable.property, mvtable.label, mvtable.value
         ).orderby(person_table.ROWID)
         fields = get_field_indices(query)
@@ -54,7 +53,7 @@ class IOSContacts(Provider):
         # We'll get several rows per contact.
         # These will be ordered by ROWID, so we should get all the values for one contact together.
         for row in self.conn.execute(str(query)):
-            rowid=row[fields['ROWID']]
+            rowid = row[fields['ROWID']]
             if rowid != prev_id and prev_id is not None:
                 # Moving on to new contact; return the last one
                 # with whatever we've found
@@ -63,9 +62,9 @@ class IOSContacts(Provider):
                     device_id=self.fs.id_,
                     providerName=self.NAME,
                     providerFriendlyName=self.FRIENDLY_NAME,
-                    name = Name(first = first, last=last),
-                    phone = phone,
-                    email = email
+                    name=Name(first=first, last=last),
+                    phone=phone,
+                    email=email
                 )
                 email = phone = first = last = ""
             first, last = row[fields['First']], row[fields['Last']]
@@ -81,11 +80,11 @@ class IOSContacts(Provider):
                 device_id=self.fs.id_,
                 providerName=self.NAME,
                 providerFriendlyName=self.FRIENDLY_NAME,
-                name = Name(first = first, last=last),
-                phone = phone,
-                email = email
+                name=Name(first=first, last=last),
+                phone=phone,
+                email=email
             )
-        
+
     PII_FIELDS = {
         'sqlite3': {
             DB_PATH: {
@@ -116,7 +115,7 @@ class IOSContacts(Provider):
             obj = cls(fs)
             if obj.is_version_compatible():
                 return obj
-        
+
         return None
 
     def get_media(self, local_id):

--- a/rime/providers/ioswhatsapp.py
+++ b/rime/providers/ioswhatsapp.py
@@ -17,23 +17,27 @@ MESSAGE_TYPE_TEXT = 0
 # WhatsApp iOS stores its timestamps as seconds since 1/1/2001.
 WA_IOS_TS_OFFSET = 978307200
 
+
 def _jid_to_phone(jid):
     if jid and '@' in jid:
         return jid.split('@')[0]
     return ''
+
 
 @dataclass
 class IosWhatsappMessageEvent:
     group_member: str  # ZWAMESSAGE.ZGROUPMEMBER
     chat_session_id: str
 
+
 @dataclass
 class IosWhatsappContact:
     chat_session_ids: list[str]  # ZWACHATSESSION.Z_PK
-    profile_push_name_id: str|None  # ZWAPROFILEPUSHNAME.Z_PK
+    profile_push_name_id: str | None  # ZWAPROFILEPUSHNAME.Z_PK
     group_member_pks: list[str]  # [ZWAZGROUPMEMBER.Z_PK]
-    partner_name: str|None
-    push_name: str|None
+    partner_name: str | None
+    push_name: str | None
+
 
 class IOSWhatsApp(Provider):
     NAME = 'ios-net.whatsapp.WhatsApp'
@@ -187,7 +191,8 @@ class IOSWhatsApp(Provider):
 
         chat = self.msgdb.execute(str(query)).fetchone()
         if not chat:
-            return MessageSession(session_id=session_id, provider=self, name="Unknown wa-ios session", participants=tuple())
+            return MessageSession(session_id=session_id, provider=self,
+                                  name="Unknown wa-ios session", participants=tuple())
 
         if chat[field_names['ZGROUPINFO']] is not None:
             # Group chat
@@ -199,7 +204,7 @@ class IOSWhatsApp(Provider):
             participants = [self._jid_to_contact(member[0]) for member in self.msgdb.execute(str(query))]
         else:
             # Private chat
-            participants = [self._jid_to_contact(chat[field_names['ZCONTACTJID']]),]
+            participants = [self._jid_to_contact(chat[field_names['ZCONTACTJID']])]
 
         return MessageSession(
             session_id=session_id,
@@ -248,7 +253,7 @@ class IOSWhatsApp(Provider):
                     push_name=row[field_names['ZPUSHNAME']],
                     chat_session_id=row[field_names['Z_PK']],
                     profile_push_name_id=row[field_names['PUSH_PK']],
-                    )
+                )
 
         # Search for missing group chat members.
         group_member_table = Table('ZWAGROUPMEMBER')

--- a/rime/providers/provider.py
+++ b/rime/providers/provider.py
@@ -6,12 +6,13 @@ from abc import ABC, abstractmethod
 
 from ..media import MediaData
 
+
 class Provider(ABC):
     NAME = None
     FRIENDLY_NAME = None  # for displaying to users
 
     PII_FIELDS = NotImplemented
-    
+
     @classmethod
     @abstractmethod
     def from_filesystem(cls, fs):
@@ -51,6 +52,7 @@ class Provider(ABC):
         Remove PII from databases known to this provider.
         """
         raise NotImplementedError
+
 
 def find_providers(fs) -> dict[str, Provider]:
     """

--- a/rime/providers/providerutils.py
+++ b/rime/providers/providerutils.py
@@ -4,6 +4,7 @@
 
 from abc import ABC, abstractmethod
 
+
 class LazyContactProvider(ABC):
     @abstractmethod
     def contact_load_all(self):
@@ -27,6 +28,7 @@ class LazyContactProvider(ABC):
         Return None if the contact could not be created (will raise KeyError in LazyContactProviderContacts)
         """
         raise NotImplementedError()
+
 
 class LazyContactProviderContacts(dict):
     """

--- a/rime/pubsub.py
+++ b/rime/pubsub.py
@@ -4,6 +4,7 @@ import traceback
 from weakref import WeakMethod
 from threading import Lock
 
+
 class Scheduler(metaclass=ABCMeta):
     @abstractmethod
     def run_on_my_thread(self, fn, *args, **kwargs):
@@ -12,6 +13,7 @@ class Scheduler(metaclass=ABCMeta):
     @abstractmethod
     def run_on_background_thread(self, fn, *args, **kwargs):
         pass
+
 
 class _Broker:
     def __init__(self):
@@ -53,12 +55,13 @@ class _Broker:
                     meth(data)
                 else:
                     callback(data)
-            except Exception as e:
+            except Exception:
                 traceback.print_exc()
 
         if remove:
             with self._lock:
                 for callback in remove:
                     self._subscribers[event].remove(callback)
+
 
 broker = _Broker()

--- a/rime/rime.py
+++ b/rime/rime.py
@@ -12,6 +12,7 @@ from .config import Config
 from .plugins import load_plugin
 from .pubsub import broker, Scheduler
 
+
 class Device:
     def __init__(self, device_id: str, fs: DeviceFilesystem, session: Session):
         self.id_ = device_id
@@ -42,14 +43,16 @@ class Device:
     def __repr__(self):
         return f"Device({self.id_})"
 
+
 FILESYSTEM_REGISTRY = threading.local()
 DEVICE_CACHE = threading.local()
 RIME = threading.local()
 
+
 class Rime:
     """
     Top-level RIME object.
-    
+
     Contains per-device sub-objects.
     """
     def __init__(self, session: Session, constants: Config, scheduler: Scheduler):

--- a/rime/session.py
+++ b/rime/session.py
@@ -3,6 +3,7 @@
 # Copyright 2023 Telemarq Ltd
 import sqlite3
 
+
 class Session:
     def __init__(self, db_path):
         self.db_path = db_path
@@ -14,7 +15,7 @@ class Session:
         if self.conn:
             try:
                 self.conn.close()
-            except:
+            except Exception:
                 pass
 
     def _create_tables(self):
@@ -36,5 +37,6 @@ class Session:
 
     def set_device_country_code(self, device_id, country_code):
         cursor = self.conn.cursor()
-        cursor.execute("INSERT OR REPLACE INTO device_country_code (id, country_code) VALUES (?, ?)", (device_id, country_code))
+        cursor.execute("INSERT OR REPLACE INTO device_country_code (id, country_code) VALUES (?, ?)",
+                       (device_id, country_code))
         self.conn.commit()

--- a/rime/sql.py
+++ b/rime/sql.py
@@ -16,10 +16,14 @@ Query = pypika.Query
 Column = pypika.Column
 Parameter = pypika.Parameter
 
+
 def _sqlite3_regexp_search(pattern, input):
     return bool(re.search(pattern, input))
 
+
 _threadsafety = None
+
+
 def _sqlite3_is_threadsafe():
     global _threadsafety
 
@@ -32,14 +36,15 @@ def _sqlite3_is_threadsafe():
             conn = sqlite3.connect(':memory:')
             res = conn.execute(
                 "SELECT * FROM pragma_compile_options WHERE compile_options LIKE 'THREADSAFE%'"
-                ).fetchone()[0]
+            ).fetchone()[0]
             conn.close()
 
             SQLITE_THREADSAFE = int(res.split('=')[1])
             # This mapping defined under sqlite3.threadsafety in the Python docs.
             _threadsafety = {0: 0, 2: 1, 1: 3}.get(SQLITE_THREADSAFE, 0)
-            
+
     return _threadsafety == 3
+
 
 def sqlite3_connect(db_path, uri=False):
     """
@@ -55,6 +60,7 @@ def sqlite3_connect(db_path, uri=False):
     conn = sqlite3.connect(db_path, uri=uri, check_same_thread=check_same_thread)
     conn.create_function('REGEXP', 2, _sqlite3_regexp_search)
     return conn
+
 
 def get_field_indices(query):
     return {select.alias or select.name: idx for idx, select in enumerate(query._selects)}

--- a/rime/subset.py
+++ b/rime/subset.py
@@ -5,16 +5,18 @@
 """
 Trace provider data access for subsetting.
 """
-from contextlib import contextmanager
 import re
 import shutil
 
 from .sql import Table, Query, Parameter
 
 MATCH_COLLATE = re.compile(r'COLLATE \w+', re.IGNORECASE)
+
+
 def _sanitise_create_table_sql(sql):
     # Remove custom collation sequences.
     return MATCH_COLLATE.sub('', sql)
+
 
 def _copy_table(src_conn, dst_conn, table_name, add_where_clause_fn):
     sql = src_conn.execute('select sql from sqlite_master where name = ?', (table_name,)).fetchone()[0]
@@ -37,6 +39,7 @@ def _copy_table(src_conn, dst_conn, table_name, add_where_clause_fn):
         insert_query = Query.into(table_name).insert(*parameters)
         dst_conn.execute(insert_query.get_sql(), row)
 
+
 class RowSubset:
     def __init__(self, table_name, primary_key):
         self.table_name = table_name
@@ -56,12 +59,14 @@ class RowSubset:
             self.table_name,
             lambda query, table: query.where(table[self.primary_key].isin(self.rows)))
 
+
 class CompleteTable:
     def __init__(self, table_name):
         self.table_name = table_name
 
     def copy(self, src_conn, dst_conn):
         _copy_table(src_conn, dst_conn, self.table_name, None)
+
 
 class Subsetter:
     def __init__(self, fs_dest):


### PR DESCRIPTION
Add dependency on `flake8` and format the `*.py` files accordingly. The `.flake8` configuration file is set to ignore some warnings to allow some flexibility when indenting split lines. Also configured to ignore some file-specific formatting warnings.  