### PR TITLE
Check and update required packages on `run_dev.sh`

### DIFF
--- a/check_dependencies.py
+++ b/check_dependencies.py
@@ -1,0 +1,36 @@
+# Check whether the currently installed packages are the ones specified
+# in the `requirements.txt` file.
+#
+# Exit with code 1 if any of the three is true:
+#   - At least one of the currently installed packages has a different
+#       version than the one specified in `requirements.txt`.
+#   - At least one of the packages in `requirements.txt` is not currently installed.
+#   - There is at leas a packages installed that is not in the `requirements.txt`.
+#
+
+import sys
+import pkg_resources
+from typing import Dict
+
+# Quick lookup of currently installed packages and their versions
+current_packages: Dict[str, str] = {}
+
+for dist in pkg_resources.working_set:
+    current_packages[dist.project_name] = dist.version
+
+with open('requirements.txt') as requirements:
+    for req in requirements:
+        # Get the package name and the version
+        project_name, version = req.split('==')
+
+        # If the package is not installed or there is a version miss-match
+        # exit with code (1)
+        if (project_name not in current_packages or current_packages[project_name] != version):
+            sys.exit(1)
+
+        # Remove the entry from the dict if it's satisfied
+        del current_packages[project_name]
+
+# There are more packages installed than the ones in the `requirements.txt`
+if len(current_packages) != 0:
+    sys.exit(1)

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -54,7 +54,24 @@ if [ ! -f .venv/bin/activate ]; then
 	fi
 	echo Virtualenv created. To re-create this environment, delete .venv.
 else
+
 	source .venv/bin/activate
+
+	# Check whether the currently installed packages are the same as
+	# the ones specified in the requirements.txt file
+	$PYTHON check_dependencies.py || EXIT_STATUS=$?
+
+	# Ask user whether to update the packages and proceed with installation when
+	# the .venv installed packages do not match the ones in the requirements.txt
+	if [ $EXIT_STATUS -eq 1 ]; then
+		echo "There is a missmatch between the currently installed packages and requirements.txt"
+		echo "Do you want to install the packages from requirements.txt with the specified versions? [y/n]"
+		read -n 1 ANSWER
+
+		if [[ $ANSWER == "y" ]]; then
+			pip install -r requirements.txt
+		fi
+	fi
 fi
 
 cd frontend


### PR DESCRIPTION
I had previously installed packages in the `.venv/` from an older `requirements.txt` file. After the `requirements.txt` was updated to add FastAPI with uvicorn, running the `run_dev.sh` was trying to start uvicorn without installing it first. 

I updated the `run_dev.sh` to check whether there is any miss-match between the packages installed in `.venv/` and the ones in `requirements.txt` and to prompt the user whether to update the installed packages.