### PR TITLE
Ignore `.DS_Store` files and files in the `example/` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ env
 docs/_build
 .venv
 frontend/node_modules
+
+# Ignore MacOS specific file
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@ docs/_build
 .venv
 frontend/node_modules
 
+# Ignore example/ directory
+example
+
 # Ignore MacOS specific file
 .DS_Store


### PR DESCRIPTION
Updates on `.gitignore` to ignore `.DS_Store` files and files under the `example/` directory.

There might be a reason to not ignore the `example/` directory though (?)